### PR TITLE
Add link text to broken links

### DIFF
--- a/database/migrations/2022_09_26_141418_add_link_text_to_broken_links.php
+++ b/database/migrations/2022_09_26_141418_add_link_text_to_broken_links.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('broken_links', function (Blueprint $table) {
+            $table->string('link_text')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('broken_links', function (Blueprint $table) {
+            $table->dropColumn('link_text');
+        });
+    }
+};

--- a/src/Jobs/CheckModelForBrokenLinks.php
+++ b/src/Jobs/CheckModelForBrokenLinks.php
@@ -2,6 +2,7 @@
 
 namespace ChrisRhymes\LinkChecker\Jobs;
 
+use ChrisRhymes\LinkChecker\Objects\Link;
 use DOMDocument;
 use Exception;
 use Illuminate\Bus\Queueable;
@@ -53,7 +54,11 @@ class CheckModelForBrokenLinks implements ShouldQueue
                     $anchorTags = $doc->getElementsByTagName('a');
 
                     foreach ($anchorTags as $anchorTag) {
-                        $this->links[] = $anchorTag->getAttribute('href');
+                        $link = new Link;
+                        $link->url = $anchorTag->getAttribute('href');
+                        $link->text = $anchorTag->nodeValue;
+
+                        $this->links[] = $link;
                     }
                 } catch (Exception $e) {
                     $className = get_class($this->model);

--- a/src/Models/BrokenLink.php
+++ b/src/Models/BrokenLink.php
@@ -13,6 +13,7 @@ class BrokenLink extends Model
         'linkable_id',
         'linkable_type',
         'broken_link',
+        'link_text',
         'exception_message',
     ];
 

--- a/src/Objects/Link.php
+++ b/src/Objects/Link.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ChrisRhymes\LinkChecker\Objects;
+
+class Link
+{
+    public string $url;
+
+    public string $text;
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,7 +20,7 @@ class ServiceProvider extends SupportServiceProvider
 
         RateLimiter::for('link-checker', function ($job) {
             return Limit::perMinute(config('link-checker.rate_limit', 5))
-                ->by(parse_url($job->link, PHP_URL_HOST));
+                ->by(parse_url($job->link->url, PHP_URL_HOST));
         });
     }
 

--- a/tests/Feature/HasBrokenLinksTraitTest.php
+++ b/tests/Feature/HasBrokenLinksTraitTest.php
@@ -18,6 +18,7 @@ it('has brokenLinks relationship', function () {
 
     $this->post->brokenLinks()->create([
         'broken_link' => 'https://a-broken-link',
+        'link_text' => 'broken link text',
         'exception_message' => 'An exception message',
     ]);
 
@@ -25,5 +26,6 @@ it('has brokenLinks relationship', function () {
 
     expect($this->post->fresh()->brokenLinks[0])
         ->broken_link->toBe('https://a-broken-link')
+        ->link_text->toBe('broken link text')
         ->exception_message->toBe('An exception message');
 });


### PR DESCRIPTION
Add the link text to make it easier to identify which link is broken in the source HTML. Pass a Link object to the CheckLinkFailed job instead of the link as a string. 