### PR TITLE
Update exception message field to be text to prevent truncation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "guzzlehttp/guzzle": "^7.2"
   },
   "require-dev": {
+    "doctrine/dbal": "^3.6",
     "orchestra/testbench": "^7.7",
     "pestphp/pest": "^1.22",
     "pestphp/pest-plugin-laravel": "^1.2",

--- a/database/migrations/2023_03_27_141418_update_exception_message_field.php
+++ b/database/migrations/2023_03_27_141418_update_exception_message_field.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('broken_links', function (Blueprint $table) {
+            $table->text('exception_message')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('broken_links', function (Blueprint $table) {
+            $table->string('exception_message')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
The exception message can be truncated if the message is longer than the string field length. This PR updates the field to a text field. 