### PR TITLE
Handle redirects and record status code

### DIFF
--- a/tests/Feature/CheckForBrokenLinksTest.php
+++ b/tests/Feature/CheckForBrokenLinksTest.php
@@ -33,6 +33,7 @@ it('finds the broken link and reports it', function () {
         'linkable_type' => 'ChrisRhymes\LinkChecker\Test\Models\Post',
         'broken_link' => 'https://this-is-broken.com',
         'link_text' => 'Broken link',
+        'exception_message' => '404 Status Code',
     ]);
 
     $this->assertDatabaseMissing('broken_links', [

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
+use ChrisRhymes\LinkChecker\Test\Models\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Http::fake([
+        'https://this-is-a-temporary-redirect.com' => Http::response(null, 302),
+        'https://www.this-is-a-permanent-redirect.co.uk' => Http::response(null, 301),
+    ]);
+
+    $this->post = Post::factory()
+        ->create([
+            'content' => '
+                <a href="https://this-is-a-temporary-redirect.com">Temporary redirect link</a>
+                <p>Some other content here</p>
+                <a href="https://www.this-is-a-permanent-redirect.co.uk">Permanent redirect link</a>',
+        ]);
+});
+
+it('records temporary and permanent redirects', function () {
+    CheckModelForBrokenLinks::dispatch($this->post, ['content']);
+
+    $this->assertDatabaseHas('broken_links', [
+        'linkable_id' => $this->post->id,
+        'linkable_type' => 'ChrisRhymes\LinkChecker\Test\Models\Post',
+        'broken_link' => 'https://this-is-a-temporary-redirect.com',
+        'link_text' => 'Temporary redirect link',
+        'exception_message' => '302 Redirect',
+    ]);
+
+    $this->assertDatabaseHas('broken_links', [
+        'linkable_id' => $this->post->id,
+        'linkable_type' => 'ChrisRhymes\LinkChecker\Test\Models\Post',
+        'broken_link' => 'https://www.this-is-a-permanent-redirect.co.uk',
+        'link_text' => 'Permanent redirect link',
+        'exception_message' => '301 Redirect',
+    ]);
+});


### PR DESCRIPTION
Resolves #10 

## Changes
- Update to record when a link is a redirect
- Record the status code when a link has failed to help notify if it is a client or server error