### PR TITLE
Ability to set custom user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A package that will check for broken links in the HTML of a specified model's fi
 - [Getting Started](#getting-started)
 - [Usage](#usage)
 - [Rate Limiting](#rate-limiting)
+- [User Agent](#user-agent)
 - [Verify SSL](#verify-ssl)
 - [Tests](#tests)
 
@@ -102,6 +103,12 @@ In order to reduce the amount of requests sent to a domain at a time, this packa
 The configuration file allows you to set the `rate_limit` to set how many requests can be sent to a single domain within a minute. The default is set to 5, so adjust as required for your circumstances.
 
 The configuration file also allows you to set the `retry_until` so the job will be retried until the time limit (in munites) is reached.
+
+## User Agent
+
+To set a custom user agent for requests sent by the link checker, set the `user_agent` in the configuration file. For example `'user_agent' => 'my-user-agent',`
+
+The default value is `link-checker`.
 
 ## Verify SSL
 

--- a/config/link-checker.php
+++ b/config/link-checker.php
@@ -21,6 +21,11 @@ return [
     'retry_until' => 10,
 
     /**
+     * Set a custom user agent
+     */
+    'user_agent' => 'link-checker',
+
+    /**
      * Describes the SSL certificate verification behavior of a request
      */
     'verify' => true,

--- a/src/Jobs/CheckLinkFailed.php
+++ b/src/Jobs/CheckLinkFailed.php
@@ -85,9 +85,10 @@ class CheckLinkFailed implements ShouldQueue
         }
 
         try {
-            $response = Http::withOptions([
-                'verify' => config('link-checker.verify', true),
-            ])
+            $response = Http::withUserAgent(config('link-checker.user_agent', 'link-checker'))
+                ->withOptions([
+                    'verify' => config('link-checker.verify', true),
+                ])
                 ->timeout(config('link-checker.timeout', 10))
                 ->get($this->link->url);
 

--- a/tests/Feature/CustomUserAgentTest.php
+++ b/tests/Feature/CustomUserAgentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
+use ChrisRhymes\LinkChecker\Test\Models\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Http::fake();
+
+    $this->post = Post::factory()
+        ->create([
+            'content' => ' <a href="https://this-is-broken.com">Broken link</a>',
+        ]);
+});
+
+it('sets a default user agent for requests', function () {
+    CheckModelForBrokenLinks::dispatch($this->post, ['content']);
+
+    Http::assertSent(function (Request $request) {
+        return $request->hasHeader('User-Agent', 'link-checker');
+    });
+});
+
+it('sets a custom user agent for requests', function () {
+    Config::set('link-checker.user_agent', 'custom-user-agent');
+
+    CheckModelForBrokenLinks::dispatch($this->post, ['content']);
+
+    Http::assertSent(function (Request $request) {
+        return $request->hasHeader('User-Agent', 'custom-user-agent');
+    });
+});


### PR DESCRIPTION
Added the ability to override the default Guzzle user agent with a custom user agent string by setting `user_agent` in the configuration. 

The default value is set to `link-checker`. 