### PR TITLE
Check if the field is a url and check it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Link Checker for Laravel
 
-A package that will check for broken links in the HTML of a specified model's fields.
+A package that will check for broken links in the specified model's fields. It will check both URL fields and fields containing HTML.
 
 ![Downloads](https://img.shields.io/packagist/dt/chrisrhymes/link-checker.svg)
 ![Downloads](https://img.shields.io/github/stars/chrisrhymes/link-checker.svg)
@@ -56,7 +56,7 @@ php artisan vendor:publish --provider="ChrisRhymes\LinkChecker\ServiceProvider"
 
 ## Usage
 
-Then you can check if the model has broken links in the html in a specific field.
+Then you can check if the model has broken links in the specified field(s).
 
 ```php
 use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
@@ -65,10 +65,10 @@ use ChrisRhymes\LinkChecker\Facades\LinkChecker;
 $post = Post::first();
 
 // Dispatch the job directly
-CheckModelForBrokenLinks::dispatch($post, ['content']);
+CheckModelForBrokenLinks::dispatch($post, ['content', 'url']);
 
 // Or using the facade
-LinkChecker::checkForBrokenLinks($post, ['content']);
+LinkChecker::checkForBrokenLinks($post, ['content', 'url']);
 ```
 
 This will queue a job to get the links from the model, which will then queue a job to check each link it finds.

--- a/src/Jobs/CheckModelForBrokenLinks.php
+++ b/src/Jobs/CheckModelForBrokenLinks.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class CheckModelForBrokenLinks implements ShouldQueue
 {
@@ -48,6 +49,16 @@ class CheckModelForBrokenLinks implements ShouldQueue
             })
             ->filter()
             ->each(function ($field) {
+                if (Str::isUrl($field)) {
+                    $link = new Link;
+                    $link->url = $field;
+                    $link->text = $field;
+
+                    $this->links[] = $link;
+
+                    return;
+                }
+
                 try {
                     $doc = new DOMDocument();
                     $doc->loadHTML($field);

--- a/tests/Database/Factories/PostFactory.php
+++ b/tests/Database/Factories/PostFactory.php
@@ -14,6 +14,7 @@ class PostFactory extends Factory
         return [
             'title' => $this->faker->words(3, true),
             'content' => $this->faker->text(),
+            'url' => $this->faker->url(),
         ];
     }
 }

--- a/tests/Database/migrations/2022_09_16_14147_create_posts_table.php
+++ b/tests/Database/migrations/2022_09_16_14147_create_posts_table.php
@@ -17,6 +17,7 @@ class CreatePostsTable extends Migration
             $table->bigIncrements('id');
             $table->string('title');
             $table->text('content');
+            $table->string('url')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/Feature/AvoidTelMailtoLinksTest.php
+++ b/tests/Feature/AvoidTelMailtoLinksTest.php
@@ -2,10 +2,7 @@
 
 use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
 use ChrisRhymes\LinkChecker\Test\Models\Post;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Http::fake();

--- a/tests/Feature/CheckForBrokenLinksTest.php
+++ b/tests/Feature/CheckForBrokenLinksTest.php
@@ -4,11 +4,8 @@ use ChrisRhymes\LinkChecker\Facades\LinkChecker;
 use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
 use ChrisRhymes\LinkChecker\Models\BrokenLink;
 use ChrisRhymes\LinkChecker\Test\Models\Post;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Http::fake([

--- a/tests/Feature/ChecksUrlFieldTest.php
+++ b/tests/Feature/ChecksUrlFieldTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
+use ChrisRhymes\LinkChecker\Models\BrokenLink;
+use ChrisRhymes\LinkChecker\Test\Models\Post;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::fake([
+        'https://this-is-broken.com' => Http::response(null, 404),
+    ]);
+
+    $this->post = Post::factory()
+        ->create([
+            'content' => '<a href="https://this-is-broken.com">Broken link</a>',
+            'url' => 'https://this-is-broken.com',
+        ]);
+});
+
+it('checks a url not in html', function () {
+    CheckModelForBrokenLinks::dispatch($this->post, ['url']);
+
+    $this->assertDatabaseHas('broken_links', [
+        'linkable_id' => $this->post->id,
+        'linkable_type' => 'ChrisRhymes\LinkChecker\Test\Models\Post',
+        'broken_link' => 'https://this-is-broken.com',
+        'link_text' => 'https://this-is-broken.com',
+        'exception_message' => '404 Status Code',
+    ]);
+});
+
+it('checks for broken links in both specified fields', function () {
+    CheckModelForBrokenLinks::dispatch($this->post, ['content', 'url']);
+
+    expect(BrokenLink::count())
+        ->toEqual(2);
+
+    $this->assertDatabaseHas('broken_links', [
+        'linkable_id' => $this->post->id,
+        'linkable_type' => 'ChrisRhymes\LinkChecker\Test\Models\Post',
+        'broken_link' => 'https://this-is-broken.com',
+        'link_text' => 'https://this-is-broken.com',
+        'exception_message' => '404 Status Code',
+    ]);
+
+    $this->assertDatabaseHas('broken_links', [
+        'linkable_id' => $this->post->id,
+        'linkable_type' => 'ChrisRhymes\LinkChecker\Test\Models\Post',
+        'broken_link' => 'https://this-is-broken.com',
+        'link_text' => 'Broken link',
+        'exception_message' => '404 Status Code',
+    ]);
+});
+
+it('ignores invalid url value', function () {
+    $postWithInvalidUrl = Post::factory()->create([
+        'url' => 'not a link',
+    ]);
+
+    CheckModelForBrokenLinks::dispatch($postWithInvalidUrl, ['url']);
+
+    Http::assertNothingSent();
+
+    expect(BrokenLink::count())
+        ->toEqual(0);
+});

--- a/tests/Feature/CustomUserAgentTest.php
+++ b/tests/Feature/CustomUserAgentTest.php
@@ -2,12 +2,9 @@
 
 use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
 use ChrisRhymes\LinkChecker\Test\Models\Post;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Http::fake();

--- a/tests/Feature/HasBrokenLinksTraitTest.php
+++ b/tests/Feature/HasBrokenLinksTraitTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use ChrisRhymes\LinkChecker\Test\Models\Post;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->post = Post::factory()

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -3,11 +3,8 @@
 use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
 use ChrisRhymes\LinkChecker\Models\BrokenLink;
 use ChrisRhymes\LinkChecker\Test\Models\Post;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Http::fake([

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -2,10 +2,7 @@
 
 use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
 use ChrisRhymes\LinkChecker\Test\Models\Post;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Http::fake([

--- a/tests/Feature/VerifySSLTest.php
+++ b/tests/Feature/VerifySSLTest.php
@@ -3,12 +3,9 @@
 use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
 use ChrisRhymes\LinkChecker\Models\BrokenLink;
 use ChrisRhymes\LinkChecker\Test\Models\Post;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Http::fake([

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,7 +11,10 @@
 |
 */
 
-uses(ChrisRhymes\LinkChecker\Test\TestCase::class)->in('Feature');
+uses(
+    ChrisRhymes\LinkChecker\Test\TestCase::class,
+    Illuminate\Foundation\Testing\RefreshDatabase::class
+)->in('Feature');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
- Added support for fields that are urls using the `Str::isUrl()` helper, instead of only fields containing HTML. 
- Tidy up feature tests to use RefreshDatabase from Pest config
- Add tests for url field 