### PR TITLE
Feature/status codes to skip

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
-      - uses: actions/checkout@v4
+          php-version: '8.4'
+      - uses: actions/checkout@v6
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
       - name: Create Database

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .phpunit.result.cache
 .phpunit.cache
 composer.lock
+.idea

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A package that will check for broken links in the specified model's fields. It w
 - [Rate Limiting](#rate-limiting)
 - [User Agent](#user-agent)
 - [Verify SSL](#verify-ssl)
+- [Skipping status codes](#skipping-status-codes)
 - [Tests](#tests)
 
 ## Getting Started
@@ -135,6 +136,21 @@ The default value is `link-checker`.
 To disable verifying the SSL certificate of the link you are checking, [publish the package configuration](#publish-the-config-optional) and then set `'verify' => false,`.
 
 This uses the HTTP client withOptions() to set the [verify request option in Guzzle](https://docs.guzzlephp.org/en/stable/request-options.html#verify).
+
+## Skipping status codes
+
+If you would like to skip specific status code responses from being reported, then you can add these to your config file.
+
+For example, to skip recording 429 or 504 response codes, add the following.
+
+```php
+// config/link-checker.php
+
+    /**
+     * Status codes to skip from reporting
+     */
+    'status_codes_to_skip' => [429, 504],
+```
 
 ## Tests
 

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
   "require-dev": {
     "doctrine/dbal": "^4.0",
     "orchestra/testbench": "^10.0",
-    "pestphp/pest": "^3.0",
-    "pestphp/pest-plugin-laravel": "^3.0",
+    "pestphp/pest": "^4.0",
+    "pestphp/pest-plugin-laravel": "^4.0",
     "laravel/legacy-factories": "^1.3",
     "laravel/pint": "^1.2"
   },

--- a/config/link-checker.php
+++ b/config/link-checker.php
@@ -29,4 +29,9 @@ return [
      * Describes the SSL certificate verification behavior of a request
      */
     'verify' => true,
+
+    /**
+     * Status codes to skip from reporting
+     */
+    'status_codes_to_skip' => [],
 ];

--- a/src/Jobs/CheckLinkFailed.php
+++ b/src/Jobs/CheckLinkFailed.php
@@ -101,7 +101,7 @@ class CheckLinkFailed implements ShouldQueue
                     ]);
             }
 
-            if ($response->failed()) {
+            if ($response->failed() && ! in_array($response->status(), config('link-checker.status_codes_to_skip', []))) {
                 $this->model->brokenLinks()
                     ->create([
                         'broken_link' => $this->link->url,

--- a/tests/Feature/StatusCodesToSkipTest.php
+++ b/tests/Feature/StatusCodesToSkipTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use ChrisRhymes\LinkChecker\Jobs\CheckModelForBrokenLinks;
+use ChrisRhymes\LinkChecker\Test\Models\Post;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->post = Post::factory()
+        ->create([
+            'content' => '
+                <a href="http://www.example.com">Visit us</a>
+                <a href="http://www.test.com">Test site</a>',
+        ]);
+});
+
+it('skips the specified status code', function (int $statusCode) {
+    Http::fake([
+        'http://www.example.com' => Http::response('404', 404),
+        'http://www.test.com' => Http::response(null, $statusCode),
+    ]);
+
+    Config::set('link-checker.status_codes_to_skip', [$statusCode]);
+
+    CheckModelForBrokenLinks::dispatch($this->post, ['content']);
+
+    expect($this->post->fresh()->brokenLinks)->toHaveCount(1);
+
+    $this->assertDatabaseHas('broken_links', [
+        'link_text' => 'Visit us',
+        'broken_link' => 'http://www.example.com',
+    ]);
+
+    $this->assertDatabaseMissing('broken_links', [
+        'link_text' => 'Test site',
+        'broken_link' => 'http://www.test.com',
+    ]);
+})->with([
+    'forbidden' => 403,
+    'Too many requests' => 429,
+    'Gateway timeout' => 504,
+]);


### PR DESCRIPTION
## Changes

- Allow skipping of recording specific status codes as broken links. 
- Update tests to use Pest v4

A new key has been added to the config file allowing you to specify the status codes you wish to skip. The default array is empty:

```php
    /**
     * Status codes to skip from reporting
     */
    'status_codes_to_skip' => [],
```

For example, this would allow skipping 429 and 504 status codes:

```php
    /**
     * Status codes to skip from reporting
     */
    'status_codes_to_skip' => [429, 504],
```

